### PR TITLE
Add "notcontains" operator

### DIFF
--- a/edges/flow_matching.py
+++ b/edges/flow_matching.py
@@ -271,7 +271,7 @@ def match_operator(value: str, target: str, operator: str) -> bool:
             return value[0].startswith(target)
     elif operator == "contains":
         return target in value
-    elif operator == "excludes":
+    elif operator == "notcontains":
         if not isinstance(value, str):
             return False
         if isinstance(target, (list, tuple)):

--- a/edges/utils.py
+++ b/edges/utils.py
@@ -84,7 +84,7 @@ def check_presence_of_required_fields(data: list):
         assert "matrix" in cf["supplier"], f"Missing matrix fields in {cf['supplier']}."
         assert "matrix" in cf["consumer"], f"Missing matrix fields in {cf['consumer']}."
         assert any(
-            x.get("operator", "equals") in ["equals", "contains", "startswith", "excludes"]
+            x.get("operator", "equals") in ["equals", "contains", "startswith", "notcontains"]
             for x in [cf["supplier"], cf["consumer"]]
         ), f"Invalid operator in {cf}."
 


### PR DESCRIPTION
### Motivations
My interns wanted to: add specific Characterization Factors (CFs) previously assigned to every elementary flows. 
We believed that these CFs values should change for some specific edges, (i) between the unit process nodes with in their name "landfill" or "tailing", (ii) and the elementary flow (biosphere) nodes.

### Problem
**According to my understanding**, this was not possible to assign different CFs value to both (1) all the edges between unit processes and biosphere nodes, **and** (2) the edges between a specific subset of unit processes ("landfill" in their names) and the biosphere nodes.

### In a general way...
Previously, Edge only supported positive string-matching operators such as "equals", "contains", and "startswith". This created a structural limitation when attempting to:
1. Assign a default CF to all edges between nodes unit processes and nodes elementary flows.
2. Override that CF for a specific subset (e.g., activities that contains in their names: "landfill" or "tailings")

### Changes introduced
1️⃣ New `notcontains` operator in `flow_matching.py`
`elif operator == "notcontains":
    if not isinstance(value, str):
        return False
    if isinstance(target, (list, tuple)):
        return all(t not in value for t in target)
    return target not in value
`
This enables proper field-level negation consistent with the existing ` contains` logic.
2️⃣ Operator validation update in `utils.py`

Extended allowed operators to include:
`x.get("operator", "equals") in ["equals", "contains", "startswith", "notcontains"]`

